### PR TITLE
Added ability for html to save selections when html is regenerated

### DIFF
--- a/scripts/database.js
+++ b/scripts/database.js
@@ -132,6 +132,10 @@ export const setFacility = (facilityId) => {
     document.dispatchEvent( new CustomEvent("stateChanged") )
 }
 
+export const setGovernor = (governorId) => {
+    database.transientState.selectedGovernor = governorId
+    document.dispatchEvent( new CustomEvent("stateChanged") )
+}
 export const setColony = (colonyId) => {
     database.transientState.selectedColony = colonyId
     document.dispatchEvent( new CustomEvent("stateChanged") )

--- a/scripts/database.js
+++ b/scripts/database.js
@@ -93,10 +93,10 @@ const database = {
         {id: 4, facilityId: 1, mineralId: 1, quantity: 200},
         {id: 5, facilityId: 4, mineralId: 1, quantity: 15},
         {id: 6, facilityId: 1, mineralId: 2, quantity: 8},
-        {id: 7, facilityId: 5, mineralId: 1, quantity: 41},
+        {id: 7, facilityId: 3, mineralId: 5, quantity: 41},
         {id: 8, facilityId: 5, mineralId: 3, quantity: 60},
         {id: 9, facilityId: 2, mineralId: 1, quantity: 984},
-        {id: 10, facilityId: 1, mineralId: 1, quantity: 49}
+        {id: 10, facilityId: 1, mineralId: 3, quantity: 49}
     ]
 }
 

--- a/scripts/facilities.js
+++ b/scripts/facilities.js
@@ -1,5 +1,5 @@
 // *Importing our facilities getter Function from database.js
-import { getFacilities } from "./database.js";
+import { getFacilities, getTransientState } from "./database.js";
 
 // *Storing the getFacilities() function inside of the facilities variale.
 let facilities = getFacilities()
@@ -11,12 +11,17 @@ let facilities = getFacilities()
 // *When loop finish, add the closing dropdown tag to the string.
 // *Return htmlString variable. 
 export const facilitiesHtml = () => {
+    let state = getTransientState()
     let htmlString = `<h3>Facilities</h3><select id="facilitySelect">
     <option value="">Choose One</option>`
     
     for (const facility of facilities) {
         if (facility.active === true) {
-        htmlString += `<option value="${facility.id}">${facility.name}</option>`
+        htmlString += `<option value="${facility.id}"`
+        if(facility.id === state.selectedFacility){ //checking state to see if current iterating facility matches transient state, making it selected if so
+            htmlString += `selected`
+        }
+        htmlString += `>${facility.name}</option>`
     }
 
 }

--- a/scripts/governors.js
+++ b/scripts/governors.js
@@ -1,16 +1,21 @@
-import { getGovernors, setColony, getColonies } from "./database.js"
+import { getGovernors, setColony, getColonies, getTransientState, setGovernor } from "./database.js"
 
 const governors = getGovernors()
 
 //define and export a function that creates the html for the governors dropdown
 export const governorsHtml = () => {
+    let state = getTransientState()
     return `<h3>Governors</h3><select id="governorSelect">
     <option value="">Choose One</option>
     ${
         governors.map(
             governor => {
+                let selected = ""
+                if(governor.id === state.selectedGovernor){
+                    selected = "selected"
+                }
                 if(governor.active === true){ //only if the governor is active
-                return `<option value="${governor.colonyId}">${governor.name}</option>`
+                return `<option value="${governor.id}--${governor.colonyId}" ${selected}>${governor.name}</option>`
                 }
             }
         ).join("")
@@ -36,14 +41,14 @@ document.addEventListener("change", (changeEvent) => {
 }
 })
 
-//set main container
-const mainContainer = document.querySelector("#container")
 
 //change event listener to set the governor's associated colonyId in transient state
-mainContainer.addEventListener(
+document.addEventListener(
     "change",
     (event) => {
         if (event.target.id === "governorSelect"){
-            setColony(parseInt(event.target.value))
+            let [governorId, colonyId] = event.target.value.split("--")
+            setColony(parseInt(colonyId))
+            setGovernor(parseInt(governorId))
         }
     })

--- a/scripts/governors.js
+++ b/scripts/governors.js
@@ -10,9 +10,9 @@ export const governorsHtml = () => {
     ${
         governors.map(
             governor => {
-                let selected = ""
+                let selected = "" //will use this to add selected property only on the option that matches state (if any)
                 if(governor.id === state.selectedGovernor){
-                    selected = "selected"
+                    selected = "selected" //setting this to "selected" if it matches state
                 }
                 if(governor.active === true){ //only if the governor is active
                 return `<option value="${governor.id}--${governor.colonyId}" ${selected}>${governor.name}</option>`


### PR DESCRIPTION
# Description

HTML now checks state to choose a selected dropdown for governor and facility. Also tweaked facilityMineral data slightly to fix a double plutonium issue


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested clicking the governor and facility dropdowns and making sure they stay selected when html regenerates

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
