### PR TITLE
Fixed updating quantities on colonyMinerals

### DIFF
--- a/scripts/colonyMinerals.js
+++ b/scripts/colonyMinerals.js
@@ -5,7 +5,7 @@ import { facilityMinerals } from "./facilityMinerals.js"
 let governors = getGovernors()
 let minerals = getMinerals()
 let colonies = getColonies()
-let colonyMinerals = getColonyMinerals()
+
 
 
 //Change Event listener to change the Colony name to depending on the Governor who is currently selected 
@@ -13,6 +13,7 @@ let colonyMinerals = getColonyMinerals()
 // when a governor is selected, display the name of their colony 
 
 export const colonyInventory = () => {
+    let colonyMinerals = getColonyMinerals()
     let htmlString = ""
 let transientState = getTransientState()
 
@@ -27,7 +28,11 @@ let transientState = getTransientState()
         for (const colonyMineral of colonyMinerals) {
             if (transientState.selectedColony === colonyMineral.colonyId) {
                 let foundMineral = minerals.find(mineral => {return mineral.id === colonyMineral.mineralId})
-                htmlString += `<li>${colonyMineral.quantity} tons of ${foundMineral.name}</li>`
+                if(colonyMineral.quantity === 1){
+                    htmlString += `<li>${colonyMineral.quantity} ton of ${foundMineral.name}</li>`
+                } else {
+                    htmlString += `<li>${colonyMineral.quantity} tons of ${foundMineral.name}</li>`
+                }
             }
         }
     

--- a/scripts/facilityMinerals.js
+++ b/scripts/facilityMinerals.js
@@ -11,6 +11,7 @@ export const facilityMinerals = () => { //creates the facility mineral header an
     let minerals = getMinerals()
     const transientState = getTransientState()
 
+
     let HTMLstr = ""
     for (let facility of facilities) {
         if (facility.id === transientState.selectedFacility) {
@@ -19,8 +20,12 @@ export const facilityMinerals = () => { //creates the facility mineral header an
                 if (facility.id === facilityMineral.facilityId) {
                     for (let mineral of minerals) {
                         if (mineral.id === facilityMineral.mineralId && facilityMineral.quantity > 0) {
+                            let selected = ""
+                            if(transientState.selectedMineral === mineral.id){
+                                selected = "checked"
+                            }
                             HTMLstr +=`<li>
-                            <input type="radio" name="mineral" value="${facilityMineral.mineralId}" /> ${facilityMineral.quantity} tons of ${mineral.name}
+                            <input ${selected} type="radio" name="mineral" value="${facilityMineral.mineralId}" /> ${facilityMineral.quantity} tons of ${mineral.name}
                             </li>`
                         }
                     }


### PR DESCRIPTION
# Description

ColonyMinerals quantities were not updating when minerals were purchased, fixed. added grammar logic for "ton" vs "tons" in colonyminerals 

Fixes # (issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Purchase minerals to see the quantity of the colony mineral go up, or even a new colony mineral to be created if it didn't yet exist

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
